### PR TITLE
Block Vote - PHR Metadata

### DIFF
--- a/input/pagecontent/datastorage.md
+++ b/input/pagecontent/datastorage.md
@@ -23,7 +23,7 @@ As such, this implementation guide recommends that implementors treat storage in
 
 #### Meta Data
 
-The `.sphr ` container should contain two meta data files.  One of these files is a Composition record, which acts like the 'cover page' of the bundle.  This record records ownership, versioning, and various other data elements necessary for parsing the record.  The second file is a DocumentManifest file, which acts as a manifest and table of contents of the container.
+The `.sphr ` container should contain two meta data files.  One of these files is a Composition record, which acts like the 'cover page' of the bundle.  This record records ownership, versioning, and various other data elements necessary for parsing the record.  The second file is an International Patient Summary, which acts as a manifest and table of contents of critical documents in the record.
 
 
 #### Compression  
@@ -50,7 +50,7 @@ Should use [NDJSON format](http://ndjson.org/) and save to a password encrypted 
 
 #### Conformance Testing
 
-For conformance testing with this IG, the primary success critieria is the ability to import/export the .sphr filetype. This entails storing FHIR records in a new-line delimited file (including a cover composition resource, a document manifest, and provenance records as needed), compressing the file with DEFLATE algorithm (as needed), and then signing with an X.509 security certificate (i.e. DNS certificate). 
+For conformance testing with this IG, the primary success critieria is the ability to import/export the .sphr filetype. This entails storing FHIR records in a new-line delimited file (including a cover composition resource, an International Patient Summary, and provenance records as needed), compressing the file with DEFLATE algorithm (as needed), and then signing with an X.509 security certificate (i.e. DNS certificate). 
 
 #### Implementation Guidance  
 

--- a/input/pagecontent/recordkeeping.md
+++ b/input/pagecontent/recordkeeping.md
@@ -88,7 +88,7 @@ A SMART Health Links based solution will distribute the encryption key within a 
 
 ### Conformance Testing
 
-For conformance testing with this IG, the primary success critieria is that systems MUST have the ability to import/export the `.sphr` filetype. This entails storing FHIR records in a new-line delimited file (including a cover composition resource, a document manifest, and provenance records as needed), compressing the file with DEFLATE algorithm (as needed), and then signing with an X.509 security certificate. 
+For conformance testing with this IG, the primary success critieria is that systems MUST have the ability to import/export the `.sphr` filetype. This entails storing FHIR records in a new-line delimited file (including a cover composition resource, an International Patient Summary, and provenance records as needed), compressing the file with DEFLATE algorithm (as needed), and then signing with an X.509 security certificate. 
 
 #### Creating a Personal Health Record    
 
@@ -121,7 +121,7 @@ The process flow below is based on encrypting files with PGP/GPG utilities, whic
 - If a directory, scan for media and supporting documents such as PDF.
 - Scan the contents of the directory for a .phr or .ndjson file.
 - Scan the .phr file for the Composition resource.
-- Scan the .phr file for the Document Manifest resource.
+- Scan the .phr file for an International Patient Summary.
 - Scan the .phr file for the primary Patient resource.
 - Scan the .phr file for provenance resources.
 - If found, decode each provenance signature and extract payload contents.


### PR DESCRIPTION
Replace all references to DocumentManifest (removed in FHIR R5) with International Patient Summary as the second metadata file in the .sphr container. Aligns datastorage.md and recordkeeping.md conformance language with the existing metadata section in recordkeeping.md.

FHIR-49619 deferred pending research on document paradigm guidance.

JIRA: https://jira.hl7.org/browse/FHIR-53583
JIRA: https://jira.hl7.org/browse/FHIR-49619

Preview:
https://build.fhir.org/ig/HL7/personal-health-record-format-ig/branches/blockvote-phr-metadata/en/